### PR TITLE
Updates for v1.3.0 taxonomy release

### DIFF
--- a/core/solar-types-2019-02-27.xsd
+++ b/core/solar-types-2019-02-27.xsd
@@ -846,6 +846,13 @@ limitations under the License.
 </complexType>
   <complexType xmlns="http://www.w3.org/2001/XMLSchema" abstract="false" mixed="false" name="uuidItemType">
     <simpleContent>
+      <xs:restriction base="xs:token">
+        <xs:pattern value="([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})|(\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\})"/>
+      </xs:restriction>
+</simpleContent>
+</complexType>
+  <complexType xmlns="http://www.w3.org/2001/XMLSchema" abstract="false" mixed="false" name="uuidXbrlItemType">
+    <simpleContent>
       <xs:restriction base="xbrli:stringItemType">
         <xs:pattern value="([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})|(\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\})"/>
       </xs:restriction>

--- a/core/solar_2019-02-27_r01.xsd
+++ b/core/solar_2019-02-27_r01.xsd
@@ -8492,7 +8492,7 @@ limitations under the License.
       nillable="true"
       solar:periodIndependent="0"
       substitutionGroup="xbrli:item"
-      type="solar-types:uuidItemType"
+      type="solar-types:uuidXbrlItemType"
       xbrli:periodType="duration"/>
     <xs:element
       id="solar_EntityIdentifierDomain"
@@ -25656,7 +25656,7 @@ limitations under the License.
       name="ProductIdentifier"
       solar:periodIndependent="true"
       substitutionGroup="xbrli:item"
-      type="solar-types:uuidItemType"
+      type="solar-types:uuidXbrlItemType"
       xbrli:periodType="duration"/>
     <xs:element
       abstract="true"


### PR DESCRIPTION
Fixes

1. Removes duplicates
2. Updates the duplicate property arc role type to identification arc role type

Updates

1. Changes the directory structure to include all the taxonomy files under the second level
2. Renames Participant to Entity
3. Removes the following elements –
   a.	UL1741SupplementAFromNRTL
   b.	UL1741FromNRTL

Additions

1. Add support for UUID
2. Includes the following new elements –
   a.	Product Code
   b.	Entity Code
   c.	Inverter Input Minimum Voltage DC